### PR TITLE
Fix dead neptune.ai blog link (redirects to acquisition page)

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@
 - [Monitoring Machine Learning Models in Production](https://christophergs.com/machine%20learning/2020/03/14/how-to-monitor-machine-learning-models)
 - [From Model-centric to Data-centric AI](https://www.youtube.com/watch?v=06-AZXmwHjo)
 - [Making Deep Learning Go Brrrr From First Principles](https://horace.io/brrr_intro.html)
-- [ML Experiment Tracking: What It Is, Why It Matters, and How to Implement It](https://neptune.ai/blog/ml-experiment-tracking)
+- [ML Experiment Tracking: What It Is, Why It Matters, and How to Implement It](https://www.bestaiweb.ai/glossary/experiment-tracking/)
 - [ML Model Baselines](https://blog.ml.cmu.edu/2020/08/31/3-baselines)
 - [[Paper] Large Scale Distributed Deep Networks](https://www.cs.toronto.edu/~ranzato/publications/DistBeliefNIPS2012_withAppendix.pdf)
 - [[Book] Machine Learning Systems](https://www.mlsysbook.ai) ([PDF](https://www.mlsysbook.ai/assets/downloads/Machine-Learning-Systems.pdf))


### PR DESCRIPTION
neptune.ai was acquired by OpenAI in December 2025 and the entire blog now 308-redirects to a press-release page, so the neptune.ai/blog link(s) below no longer lead to the referenced article(s).

This PR fixes 1 dead link in `README.md`: the *"ML Experiment Tracking: What It Is, Why It Matters, and How to Implement It"* entry now points to a live page covering the same topic: https://www.bestaiweb.ai/glossary/experiment-tracking/

**Disclosure:** I'm one of the authors of bestaiweb.ai. I've suggested our link because the page genuinely covers the same ground as the dead article. Happy to switch it to the Wayback snapshot of the original instead if you prefer: https://web.archive.org/web/20251127141526/https://neptune.ai/blog/ml-experiment-tracking